### PR TITLE
ctfs: dead players are not shown

### DIFF
--- a/FIXME
+++ b/FIXME
@@ -2022,7 +2022,6 @@ No locals.
 * cpma ctfs:  round scoreboard show in warmup  ctfs1.dm_68
 * cpma ctfs:  round alive status not update in scoreboard  ctfs1.dm_68
 * ctfs1.dm_68 showing red scored instead of blue
-* cpma ctfs:  dead player still being rendered ctfs1.dm_68
 * info screen should show map substitutions and force map setting
 * cpma ctfs always says 'defend the flag'
 * cpma ctfs ctfs1.dm_68 wcstats not showing kills/deaths

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -5436,10 +5436,9 @@ void CG_Player ( centity_t *cent ) {
 
 
 	//FIXME hack so you don't draw demo taker in third person when following in ca
-	if (cgs.gametype == GT_CA  &&  cent->currentState.number == cg.clientNum  &&  cg.snap->ps.pm_type == PM_SPECTATOR) {
+	if ( ( cgs.gametype == GT_CA || cgs.gametype == GT_CTFS ) &&  cent->currentState.number == cg.clientNum  &&  cg.snap->ps.pm_type == PM_SPECTATOR) {
 		return;
 	}
-
 
 	if (cent->currentState.number == cent->currentState.clientNum  &&  cent->currentState.weapon == WP_NONE  &&  !(cent->currentState.eFlags & EF_DEAD)) {
 		//return;


### PR DESCRIPTION
Before fixing bug also was able to be reproduced if playing Quake Live with Attack & Defend mode and g_teamSpecFreeCam 1.