### PR TITLE
hiding players with PM_SPECTATOR and showing players from TEAM_SPECTATOR

### DIFF
--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -5437,9 +5437,8 @@ void CG_Player ( centity_t *cent ) {
 		return;
 	}
 
-
-	//FIXME hack so you don't draw demo taker in third person when following in ca
-	if ( ( cgs.gametype == GT_CA || cgs.gametype == GT_CTFS) &&  cent->currentState.number == cg.clientNum  &&  cg.snap->ps.pm_type == PM_SPECTATOR) {
+	// don't draw spectators
+	if ( cent->currentState.number == cg.clientNum  &&  cg.snap->ps.pm_type == PM_SPECTATOR) {
 		return;
 	}
 
@@ -5474,10 +5473,6 @@ void CG_Player ( centity_t *cent ) {
 	// not have valid clientinfo
 	if ( !ci->infoValid ) {
 		//Com_Printf("info invalid for %d\n", clientNum);
-		return;
-	}
-
-	if (ci->team == TEAM_SPECTATOR) {
 		return;
 	}
 


### PR DESCRIPTION
Reason to make this patch: https://www.sendspace.com/file/35bsaz

There is a player with name imbecilla (client_id = 6, starting a fight with him at 2:00). For some reason in this demo his configstring shows team 3 (specator team), and AFAIK this is the reason why his clientInfo->team is TEAM_SPECTATOR. Due this, he is not drawn in wolfcamql. Meanwhile in original quake live he is drawn.

This patch fixed this problem. All players with PM_SPECTATOR are treated as specators.