### PR TITLE
not showing specator in crosshair scan

### DIFF
--- a/FIXME
+++ b/FIXME
@@ -2028,7 +2028,6 @@ No locals.
 * cpma ft frozen player shows harvester icons, thawing teammate shows as frag with watch your fire message, round starts
 * seeking register user country flag failed spam
 * dedicated win32 loadlibrary error always "unknown"
-* dead invisible demo taker shown in crosshair client scan :  invis-demo-taker-24-00.dm_91
 * /follow victim, switch to freecam [ENTER] and player is not visible
 * with protocol 91 demos and free spec can show team overlay for both teams
 * draw keypress:  walk (LEGS_WALK)

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -8529,6 +8529,10 @@ static void CG_DrawCrosshairNames( void ) {
 		return;
 	}
 
+	if (cg_entities[cg.crosshairClientNum].currentState.eFlags & EF_DEAD) {
+		return;
+	}
+
 	if (*cg_drawCrosshairNamesFont.string) {
 		font = &cgs.media.crosshairNamesFont;
 	} else {
@@ -8614,7 +8618,12 @@ static void CG_DrawCrosshairTeammateHealth (void)
 	if (!cg_drawCrosshairTeammateHealth.integer) {
 		return;
 	}
+
 	if (cg.crosshairClientNum < 0  ||  cg.crosshairClientNum >= MAX_CLIENTS) {
+		return;
+	}
+
+	if (cg_entities[cg.crosshairClientNum].currentState.eFlags & EF_DEAD) {
 		return;
 	}
 


### PR DESCRIPTION
works both for dead players and spectator team players.