### PR TITLE
ignoring g_overtime value for round-based gametypes

### DIFF
--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -5160,7 +5160,18 @@ int CG_GetCurrentTimeWithDirection (int *numberOfOvertimes)
 
 	  } else if (cgs.realTimelimit) {
 		  if (timePlayed > (cgs.timelimit * 60 * 1000)) {
-			  overTimeAmount = atoi(Info_ValueForKey(CG_ConfigString(CS_SERVERINFO), "g_overtime")) * 1000;
+				switch(cgs.gametype) {
+					case GT_CA:
+					case GT_CTFS:
+					case GT_RED_ROVER:
+					case GT_FREEZETAG:
+						overTimeAmount = 0;
+						break;
+
+					default:
+						overTimeAmount = atoi(Info_ValueForKey(CG_ConfigString(CS_SERVERINFO), "g_overtime")) * 1000;
+						break;
+				}
 			  if (overTimeAmount) {
 				  numOverTimes = (timePlayed - (cgs.timelimit * 60 * 1000)) / overTimeAmount;
 				  // above value is zero based index


### PR DESCRIPTION
Original quake live ignores g_overtime for round-based gametypes.
Reason to make this commit is weird overtime count incrementing in demo below.
`/seekclock 19:57`

[AD-eugene-infinity-2018_01_06-21_24_48.tar.gz](https://github.com/brugal/wolfcamql/files/1609238/AD-eugene-infinity-2018_01_06-21_24_48.tar.gz)
