### PR TITLE
Fixed stuttering in cg_animationsRate at low timescales.

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -11186,7 +11186,7 @@ void CG_DrawActive( stereoFrame_t stereoView ) {
 	if (cg_animationsIgnoreTimescale.integer) {
 		cg.refdef.time = cg.realTime;
 	}
-	cg.refdef.time *= cg_animationsRate.value;
+	cg.refdef.time = cg.ftime * cg_animationsRate.value;
 
 	if (0) {  //(cg.demoSeeking) {
 		trap_R_ClearScene();


### PR DESCRIPTION
The stuttering was fixed using cg.ftime to caluculate animation time, not cg.time

the videos are recorded with timescale 0.01 and cg_animationsRate 100

before (stuttering):

https://user-images.githubusercontent.com/56254316/136129272-fb0cc6c4-5a4a-4bd2-840f-b6689c25595a.mp4

after (fixed):

https://user-images.githubusercontent.com/56254316/136129264-29476d55-feda-4270-841d-f5c62e81e73d.mp4


