### PR TITLE
cg_damageFeedbackInterval cvar to control cg_kickScale and cg_screenDamage

### DIFF
--- a/README-wolfcam.txt
+++ b/README-wolfcam.txt
@@ -1490,6 +1490,7 @@ Available tokens:
 * cg_gunSize (first person) and cg_gunSizeThirdPerson
 
 * cg_kickScale same as quakelive
+* cg_damageFeedbackInterval   Minimum time in milliseconds between view kicks (cg_kickScale) and damage blobs (cg_screenDamage) when taking damage.
 * cg_fallKick (0: no view or weapon change, 1: (default) view and weapon change, 2: only weapon sway)
 
 * cg_crosshairColor "0xffffff"

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1187,6 +1187,10 @@ typedef struct {
 	float		damageTime;
 	float		damageX, damageY, damageValue;
 
+	// damage feedback
+	int			lastDamageTime;
+	int			nextDamageFeedbackTime;
+
 	// status bar head
 	float		headYaw;
 	float		headEndPitch;
@@ -3596,6 +3600,7 @@ extern vmCvar_t cg_animationsRate;
 extern vmCvar_t cg_quadFireSound;
 extern vmCvar_t cg_kickScale;
 extern vmCvar_t cg_fallKick;
+extern vmCvar_t cg_damageFeedbackInterval;
 
 // referenced in menu files with cvarTest
 extern vmCvar_t cg_gameType;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -1154,6 +1154,7 @@ vmCvar_t cg_animationsRate;
 vmCvar_t cg_quadFireSound;
 vmCvar_t cg_kickScale;
 vmCvar_t cg_fallKick;
+vmCvar_t cg_damageFeedbackInterval;
 
 vmCvar_t cg_gameType;
 vmCvar_t cg_compMode;
@@ -2408,6 +2409,7 @@ static cvarTable_t cvarTable[] = { // bk001129
 	{ &cg_animationsRate, "cg_animationsRate", "1", CVAR_ARCHIVE },
 	{ &cg_quadFireSound, "cg_quadFireSound", "1", CVAR_ARCHIVE },
 	{ &cg_kickScale, "cg_kickScale", "0", CVAR_ARCHIVE },
+	{ &cg_damageFeedbackInterval, "cg_damageFeedbackInterval", "800", CVAR_ARCHIVE },
 	{ cvp(cg_fallKick), "1", CVAR_ARCHIVE },
 	{ &cg_gameType, "cg_gameType", "0", CVAR_ARCHIVE },
 	{ &cg_compMode, "cg_compMode", "0", CVAR_ARCHIVE },

--- a/code/cgame/cg_playerstate.c
+++ b/code/cgame/cg_playerstate.c
@@ -473,9 +473,17 @@ static void CG_DamageFeedback( int yawByte, int pitchByte, int damage ) {
 	if ( kick > 10 ) {
 		kick = 10;
 	}
+
+	if (cg_damageFeedbackInterval.integer > 0 &&
+    	cg.time < cg.nextDamageFeedbackTime &&
+    	(cg.nextDamageFeedbackTime - cg.time) <= (cg_damageFeedbackInterval.integer + 1)) {
+    	return;
+	}
+
 	cg.damageValue = kick;
 	cg.v_dmg_time = cg.time + DAMAGE_TIME;
 	cg.damageTime = cg.snap->serverTime;
+	cg.nextDamageFeedbackTime = cg.time + cg_damageFeedbackInterval.integer;
 }
 
 


### PR DESCRIPTION
Getting peppered by LG with cg_kickScale and cg_screenDamage enabled looks jittery/chaotic/bad. So I made a cvar that controls minimum interval of these effects in ms.

before (no control):
https://github.com/user-attachments/assets/07837a33-6f3c-4ce6-b12e-785fa7eb7e0c

after (cg_damageFeedbackInterval "800")
https://github.com/user-attachments/assets/2382ef54-a330-44e8-b6a8-de661cc632e9

...also I set it to 800 by default because thats how it looked like in old QL.

